### PR TITLE
Update docs about rewritten tweet links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 An easy way to synchronize your Twitter's tweets to Mastodon & Bluesky posts. 🦤 → 🦣+☁️.
 
+When a tweet links to another tweet already synchronized by Touitomamout, that link is automatically rewritten to the Mastodon or Bluesky URL of the cross‑posted content.
+
 [![Release](https://img.shields.io/github/package-json/v/louisgrasset/touitomamout/main?label=release&color=#4c1)](https://github.com/louisgrasset/touitomamout/releases)
 [![License](https://img.shields.io/github/license/louisgrasset/touitomamout?color=#4c1)](https://github.com/louisgrasset/touitomamout/blob/main/LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/louisgrasset/touitomamout)](https://github.com/louisgrasset/touitomamout/graphs/contributors)

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -24,6 +24,10 @@ Videos are not supported on Bluesky yet. But it will be soon 🤞! Until then, t
 be synced without the media. If no text and no compatible media is found, the post will be skipped during sync.
 :::
 
+:::note
+If a tweet includes a link to another tweet already synchronized by Touitomamout, the link is rewritten to the Mastodon or Bluesky URL of that cross‑posted content.
+:::
+
 ## How is synchronization working?
 
 ### Content synchronization


### PR DESCRIPTION
## Summary
- mention that links to tweets are rewritten to Mastodon/Bluesky equivalents

## Testing
- `npm test` *(fails: vitest not installed)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687413dfc8708327bf2fefbb7d86b3c3