### PR TITLE
Fix missing check when building Mastodon quote links

### DIFF
--- a/src/helpers/tweet/split-tweet-text/get-mastodon-quote-link-section.ts
+++ b/src/helpers/tweet/split-tweet-text/get-mastodon-quote-link-section.ts
@@ -15,6 +15,9 @@ export const getMastodonQuoteLinkSection = async (
     "last",
     quotedTweetId,
   );
+  if (!mastodonQuotedId) {
+    return "";
+  }
 
   return `\n\nhttps://${MASTODON_INSTANCE}/@${mastodonUsername}/${mastodonQuotedId}`;
 };


### PR DESCRIPTION
## Summary
- avoid generating invalid link if quoted tweet wasn't synced

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727728e7e08327940d0637035aa2f4