### PR TITLE
Add synced post link replacement helper

### DIFF
--- a/src/helpers/url/__tests__/replace-synced-post-links.spec.ts
+++ b/src/helpers/url/__tests__/replace-synced-post-links.spec.ts
@@ -1,0 +1,58 @@
+import { Platform } from "../../../types";
+import { replaceSyncedPostLinks } from "../replace-synced-post-links";
+
+vi.mock("../../cache/get-cached-posts", () => ({
+  getCachedPosts: vi.fn(),
+}));
+
+vi.mock("../../../constants", () => ({
+  MASTODON_INSTANCE: "mastodon.social",
+}));
+
+const getCachedPostsMock = (await import("../../cache/get-cached-posts")).getCachedPosts as vi.Mock;
+
+describe("replaceSyncedPostLinks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should leave links unchanged when no cache entry exists", async () => {
+    getCachedPostsMock.mockResolvedValue({});
+
+    const text = "Check https://twitter.com/user/status/1";
+    const urls = ["https://twitter.com/user/status/1"];
+    const result = await replaceSyncedPostLinks(text, urls, Platform.MASTODON, "mastouser");
+
+    expect(result).toEqual({ text, urls });
+  });
+
+  it("should replace links for Mastodon", async () => {
+    getCachedPostsMock.mockResolvedValue({
+      "1": { [Platform.MASTODON]: ["999"] },
+    });
+
+    const text = "Check https://x.com/user/status/1";
+    const urls = ["https://x.com/user/status/1"];
+    const result = await replaceSyncedPostLinks(text, urls, Platform.MASTODON, "alice");
+
+    expect(result).toEqual({
+      text: "Check https://mastodon.social/@alice/999",
+      urls: ["https://mastodon.social/@alice/999"],
+    });
+  });
+
+  it("should replace links for Bluesky", async () => {
+    getCachedPostsMock.mockResolvedValue({
+      "2": { [Platform.BLUESKY]: [{ cid: "cid", rkey: "rkey" }] },
+    });
+
+    const text = "See https://twitter.com/user/status/2";
+    const urls = ["https://twitter.com/user/status/2"];
+    const result = await replaceSyncedPostLinks(text, urls, Platform.BLUESKY, "bob.bsky.social");
+
+    expect(result).toEqual({
+      text: "See https://bsky.app/profile/bob.bsky.social/post/rkey",
+      urls: ["https://bsky.app/profile/bob.bsky.social/post/rkey"],
+    });
+  });
+});

--- a/src/helpers/url/replace-synced-post-links.ts
+++ b/src/helpers/url/replace-synced-post-links.ts
@@ -1,0 +1,44 @@
+import { MASTODON_INSTANCE } from "../../constants";
+import { Platform, BlueskyCacheChunk } from "../../types";
+import { getCachedPosts } from "../cache/get-cached-posts";
+
+export const replaceSyncedPostLinks = async (
+  text: string,
+  urls: string[],
+  platform: Platform,
+  username: string,
+): Promise<{ text: string; urls: string[] }> => {
+  const cachedPosts = await getCachedPosts();
+  const TWITTER_STATUS_LINK = /https:\/\/(?:twitter\.com|x\.com)\/[^/]+\/status\/(\d+)/g;
+
+  let replacedText = text;
+  const updatedUrls = [...urls];
+
+  for (const match of text.matchAll(TWITTER_STATUS_LINK)) {
+    const tweetId = match[1];
+    const cached = cachedPosts[tweetId]?.[platform];
+    if (!cached) continue;
+
+    let newUrl: string | undefined;
+    if (platform === Platform.MASTODON) {
+      const ids = cached as string[];
+      const cachedId = ids[ids.length - 1];
+      newUrl = `https://${MASTODON_INSTANCE}/@${username}/${cachedId}`;
+    } else if (platform === Platform.BLUESKY) {
+      const chunks = cached as BlueskyCacheChunk[];
+      const { rkey } = chunks[chunks.length - 1];
+      newUrl = `https://bsky.app/profile/${username}/post/${rkey}`;
+    }
+
+    if (newUrl) {
+      replacedText = replacedText.replaceAll(match[0], newUrl);
+      updatedUrls.forEach((u, i) => {
+        if (u === match[0]) {
+          updatedUrls[i] = newUrl!;
+        }
+      });
+    }
+  }
+
+  return { text: replacedText, urls: updatedUrls };
+};


### PR DESCRIPTION
## Summary
- add helper to replace tweet URLs with platform equivalents
- test replacement for Mastodon and Bluesky

## Testing
- `npm ci` *(fails: network disabled)*
- `npm test` *(not run due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_687413dd8dd083278cf288aa9a285af9