### PR TITLE
Handle null tweets during synchronization

### DIFF
--- a/src/services/posts-synchronizer.service.ts
+++ b/src/services/posts-synchronizer.service.ts
@@ -32,7 +32,13 @@ export const postsSynchronizerService = async (
     let justSynced = 0;
     while (queue.length) {
       const item = queue[0];
-      const tweet = tweetFormatter(await twitterClient.getTweet(item.id));
+      const fetchedTweet = await twitterClient.getTweet(item.id);
+      if (!fetchedTweet) {
+        queue.shift();
+        await writeQueue(queue);
+        continue;
+      }
+      const tweet = tweetFormatter(fetchedTweet);
       tweetIndex++;
       const log = ora({
         color: "cyan",


### PR DESCRIPTION
## Summary
- skip synchronization steps when a tweet cannot be fetched
- add regression test for skipping null tweets

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878df4571d48327bd9c98b9505d047a