### PR TITLE
Fix thread collector queue id checks

### DIFF
--- a/src/services/thread-collector.service.ts
+++ b/src/services/thread-collector.service.ts
@@ -48,6 +48,9 @@ export const threadCollectorService = async (
   const tweetsIterator = twitterClient.getTweets(TWITTER_HANDLE, 200);
   for await (const raw of tweetsIterator) {
     const formatted = tweetFormatter(raw as Tweet);
+    if (!formatted.id) {
+      continue;
+    }
     if (isTweetCached(formatted, cachedPosts) || queuedIds.has(formatted.id)) {
       continue;
     }
@@ -64,11 +67,14 @@ export const threadCollectorService = async (
     );
 
     for (const t of thread) {
+      if (!t.id) {
+        continue;
+      }
       if (queuedIds.has(t.id) || isTweetCached(t, cachedPosts)) {
         continue;
       }
       queue.push({
-        id: t.id!,
+        id: t.id,
         timestamp: t.timestamp ?? Date.now(),
         inReplyToStatusId: t.inReplyToStatusId,
       });


### PR DESCRIPTION
## Summary
- guard against missing tweet IDs when queuing threads

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e03acd8483278ac9cc662f36ecd7