### PR TITLE
Update cache file documentation

### DIFF
--- a/docs/docs/resources/storage/cache-system.md
+++ b/docs/docs/resources/storage/cache-system.md
@@ -4,24 +4,28 @@ title: Storage system
 
 # Cache system
 To resume the sync process where it stopped, Touitomamout keeps track of the already synced tweets. This is done by storing the tweet's id in a file.
-A `Cache` file is always named with the following naming: `cache.<source-twitter-username>.json`.
+A cache file is named `cache.<twitter-username>.json` and stored in `STORAGE_DIR` (defaults to the project root).
 
 ## Cache file location
-The cache file is stored in at the root level of the project.
+The cache file lives in `STORAGE_DIR`. If this variable is not set, it defaults to the project root.
 
 ## Cache file format
-Here is an example of a cache file:
+Version **0.2** introduces a structured cache with four top-level fields.
 ```json
 {
-  "<source-twitter-username>": {
-    "<tweet-id>": {
-      "mastodon": "<corresponding-mastodon-post-id>",
-      "bluesky": {
-        "cid": "<corresponding-bluesky-post-cid",
-        "rkey": "<corresponding-bluesky-post-rkey"
-      }
-    }
+  "version": "0.2",
+  "instance": { "id": "<twitter-username>" },
+  "profile": {
+    "avatar": "<avatar>",
+    "banner": "<banner>"
   },
-  "version": "x.x"
+  "posts": {
+    "<tweet-id>": {
+      "mastodon": ["<mastodon-post-id>"],
+      "bluesky": [
+        { "cid": "<bluesky-post-cid>", "rkey": "<bluesky-post-rkey>" }
+      ]
+    }
+  }
 }
 ```


### PR DESCRIPTION
## Summary
- document cache schema version 0.2
- mention STORAGE_DIR for cache file location

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879093ab4d883279a51c2d473b5fe46