### PR TITLE
Add LinkedIn sender service

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,9 @@ export const MASTODON_ACCESS_TOKEN = (
 export const BLUESKY_INSTANCE = (process.env.BLUESKY_INSTANCE ?? "").trim();
 export const BLUESKY_IDENTIFIER = (process.env.BLUESKY_IDENTIFIER ?? "").trim();
 export const BLUESKY_PASSWORD = (process.env.BLUESKY_PASSWORD ?? "").trim();
+export const LINKEDIN_SESSION_COOKIE = (
+  process.env.LINKEDIN_SESSION_COOKIE ?? ""
+).trim();
 export const INSTANCE_ID = (TWITTER_HANDLE ?? "instance")
   .toLowerCase()
   .trim()
@@ -47,6 +50,7 @@ export const COOKIES_PATH = `${STORAGE_DIR}/cookies.${INSTANCE_ID}.json`;
 export const QUEUE_PATH = `${STORAGE_DIR}/queue.${INSTANCE_ID}.json`;
 export const SYNC_MASTODON = (process.env.SYNC_MASTODON ?? "false") === "true";
 export const SYNC_BLUESKY = (process.env.SYNC_BLUESKY ?? "false") === "true";
+export const SYNC_LINKEDIN = (process.env.SYNC_LINKEDIN ?? "false") === "true";
 export const BACKDATE_BLUESKY_POSTS =
   (process.env.BACKDATE_BLUESKY_POSTS ?? "true") === "true";
 export const SYNC_FREQUENCY_MIN = parseInt(

--- a/src/helpers/cache/save-post-to-cache.ts
+++ b/src/helpers/cache/save-post-to-cache.ts
@@ -1,9 +1,9 @@
-import { BlueskyCache, MastodonCache, Platform } from "../../types";
+import { BlueskyCache, MastodonCache, LinkedInCache, Platform } from "../../types";
 import { getCachedPosts } from "./get-cached-posts";
 import { updateCacheEntry } from "./update-cache-entry";
 
 interface PostToCache {
-  data: MastodonCache | BlueskyCache;
+  data: MastodonCache | BlueskyCache | LinkedInCache;
   tweetId?: string;
   platform: Platform;
 }

--- a/src/services/__tests__/linkedin-sender.service.spec.ts
+++ b/src/services/__tests__/linkedin-sender.service.spec.ts
@@ -1,0 +1,86 @@
+import ora from "ora";
+
+import { makeBlobFromFile } from "../../helpers/medias/__tests__/helpers/make-blob-from-file";
+import { Media } from "../../types";
+import { linkedinSenderService } from "../linkedin-sender.service";
+import { mediaDownloaderService } from "../media-downloader.service";
+
+vi.mock("../../constants", () => ({
+  DEBUG: false,
+}));
+vi.mock("../media-downloader.service", () => ({
+  mediaDownloaderService: vi.fn(),
+}));
+vi.mock("../linkedin-sender.service", async () => {
+  const actual = await vi.importActual("../linkedin-sender.service");
+  return { ...actual };
+});
+const mediaDownloaderServiceMock = mediaDownloaderService as vi.Mock;
+
+const setInputFiles = vi.fn();
+const type = vi.fn();
+const click = vi.fn();
+const waitForSelector = vi.fn();
+const waitForNavigation = vi.fn();
+const url = vi.fn().mockReturnValue("https://linkedin.com/posts/1");
+const setCookie = vi.fn();
+const goto = vi.fn();
+const close = vi.fn();
+const page = {
+  setCookie,
+  goto,
+  waitForSelector,
+  click,
+  type,
+  setInputFiles,
+  waitForNavigation,
+  url,
+};
+const newPage = vi.fn().mockResolvedValue(page);
+
+vi.mock("puppeteer", () => ({
+  default: {
+    launch: vi.fn().mockResolvedValue({ newPage, close }),
+  },
+}));
+
+const sessionCookie = "cookie";
+const tweetId = "123";
+const text = "Post text";
+const log = ora();
+
+const media: Media = {
+  type: "image",
+  id: "id",
+  url: "https://placehold.co/10x10.png",
+  alt_text: "alt",
+};
+
+describe("linkedinSenderService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should send the post", async () => {
+    await linkedinSenderService(sessionCookie, tweetId, text, [], log);
+
+    expect(newPage).toHaveBeenCalled();
+    expect(type).toHaveBeenCalledWith('div[role="textbox"]', text);
+    expect(setInputFiles).toHaveBeenCalledTimes(0);
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("should send the post with media", async () => {
+    const blob = await makeBlobFromFile("image-png.png", "image/png");
+    mediaDownloaderServiceMock.mockResolvedValueOnce(blob);
+    await linkedinSenderService(sessionCookie, tweetId, text, [media], log);
+
+    expect(setInputFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("should skip when no content", async () => {
+    await linkedinSenderService(sessionCookie, tweetId, "", [], log);
+
+    expect(newPage).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/posts-synchronizer-service.spec.ts
+++ b/src/services/__tests__/posts-synchronizer-service.spec.ts
@@ -6,6 +6,7 @@ import { mastodon } from "masto";
 import { blueskySenderService } from "../bluesky-sender.service";
 import { mastodonSenderService } from "../mastodon-sender.service";
 import { postsSynchronizerService } from "../posts-synchronizer.service";
+import { linkedinSenderService } from "../linkedin-sender.service";
 import { MockTwitterClient } from "./mocks/twitter-client";
 import { makeTweetMock } from "./helpers/make-tweet-mock";
 
@@ -56,12 +57,18 @@ vi.mock("../bluesky-sender.service", () => ({
 vi.mock("../mastodon-sender.service", () => ({
   mastodonSenderService: vi.fn(),
 }));
+vi.mock("../linkedin-sender.service", () => ({
+  linkedinSenderService: vi.fn(),
+}));
 
 const mastodonSenderServiceMock = (
   mastodonSenderService as vi.Mock
 ).mockImplementation(() => Promise.resolve());
 const blueskySenderServiceMock = (
   blueskySenderService as vi.Mock
+).mockImplementation(() => Promise.resolve());
+const linkedinSenderServiceMock = (
+  linkedinSenderService as vi.Mock
 ).mockImplementation(() => Promise.resolve());
 
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,7 @@
 export * from "./bluesky-sender.service";
 export * from "./mastodon-sender.service";
 export * from "./media-downloader.service";
+export * from "./linkedin-sender.service";
 export * from "./posts-synchronizer.service";
 export * from "./profile-synchronizer.service";
 export * from "./tweets-getter.service";

--- a/src/services/linkedin-sender.service.ts
+++ b/src/services/linkedin-sender.service.ts
@@ -1,0 +1,72 @@
+import puppeteer from "puppeteer";
+import { Ora } from "ora";
+
+import { DEBUG, VOID } from "../constants";
+import { savePostToCache } from "../helpers/cache/save-post-to-cache";
+import { getPostExcerpt } from "../helpers/post/get-post-excerpt";
+import { LinkedInCacheChunk, Media, Platform } from "../types";
+import { mediaDownloaderService } from "./";
+
+export const linkedinSenderService = async (
+  sessionCookie: string | null,
+  tweetId: string | null,
+  text: string | null,
+  medias: Media[],
+  log: Ora,
+) => {
+  if (!sessionCookie || !tweetId) {
+    return;
+  }
+  if (!text && !medias.length) {
+    log.warn(
+      `\uD83D\uDD17 | post skipped: no compatible media nor text to post (tweet: ${tweetId})`,
+    );
+    return;
+  }
+
+  const browser = await puppeteer.launch({ headless: "new" });
+  const page = await browser.newPage();
+  await page.setCookie({
+    name: "li_at",
+    value: sessionCookie,
+    domain: ".linkedin.com",
+    path: "/",
+  });
+
+  log.text = `\uD83D\uDD17 | post sending: ${getPostExcerpt(text ?? VOID)}`;
+  await page.goto("https://www.linkedin.com/feed/");
+  await page.waitForSelector('button.share-box-feed-entry__trigger');
+  await page.click('button.share-box-feed-entry__trigger');
+  await page.waitForSelector('div[role="textbox"]');
+  if (text) {
+    await page.type('div[role="textbox"]', text);
+  }
+
+  const images = medias.filter((m) => m.type === "image" && m.url);
+  for (const media of images) {
+    const blob = await mediaDownloaderService(media.url!);
+    const buffer = Buffer.from(await blob.arrayBuffer());
+    await page.setInputFiles('input[type="file"]', {
+      name: `${media.id}.png`,
+      mimeType: blob.type,
+      buffer,
+    });
+  }
+
+  await page.click('button.share-actions__primary-action');
+  await page.waitForNavigation({ waitUntil: "networkidle0" }).catch(() => null);
+  const postUrl = page.url();
+  await browser.close();
+
+  if (DEBUG) {
+    console.log(`LinkedIn posted URL: ${postUrl}`);
+  }
+
+  await savePostToCache({
+    tweetId,
+    data: [postUrl] as LinkedInCacheChunk[],
+    platform: Platform.LINKEDIN,
+  });
+
+  log.succeed(`\uD83D\uDD17 | post sent: ${getPostExcerpt(text ?? VOID)}`);
+};

--- a/src/services/posts-synchronizer.service.ts
+++ b/src/services/posts-synchronizer.service.ts
@@ -4,7 +4,11 @@ import { Scraper } from "@the-convocation/twitter-scraper";
 import { mastodon } from "masto";
 import ora from "ora";
 
-import { SYNC_DRY_RUN } from "../constants";
+import {
+  SYNC_DRY_RUN,
+  SYNC_LINKEDIN,
+  LINKEDIN_SESSION_COOKIE,
+} from "../constants";
 import { getCachedPosts } from "../helpers/cache/get-cached-posts";
 import { oraPrefixer } from "../helpers/logs";
 import { makePost } from "../helpers/post/make-post";
@@ -12,6 +16,7 @@ import { writeQueue } from "../helpers/queue";
 import { Media, Metrics, SynchronizerResponse } from "../types";
 import { blueskySenderService } from "./bluesky-sender.service";
 import { mastodonSenderService } from "./mastodon-sender.service";
+import { linkedinSenderService } from "./linkedin-sender.service";
 import { threadCollectorService } from "./thread-collector.service";
 import { tweetFormatter } from "../helpers/tweet/tweet-formatter";
 
@@ -61,8 +66,17 @@ export const postsSynchronizerService = async (
       if (!SYNC_DRY_RUN) {
         await mastodonSenderService(mastodonClient, mastodonPost, medias, log);
         await blueskySenderService(blueskyClient, blueskyPost, medias, log);
+        if (SYNC_LINKEDIN) {
+          await linkedinSenderService(
+            LINKEDIN_SESSION_COOKIE,
+            tweet.id,
+            tweet.text,
+            medias,
+            log,
+          );
+        }
       }
-      if (mastodonClient || blueskyPost) {
+      if (mastodonClient || blueskyPost || SYNC_LINKEDIN) {
         synchronizedPostsCountThisRun.inc();
       }
 

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -1,4 +1,5 @@
 export enum Platform {
   MASTODON = "mastodon",
   BLUESKY = "bluesky",
+  LINKEDIN = "linkedin",
 }

--- a/src/types/postsCache.ts
+++ b/src/types/postsCache.ts
@@ -5,15 +5,18 @@ export type BlueskyCacheChunk = {
   cid: string;
   rkey: string;
 };
+export type LinkedInCacheChunk = string;
 
 export type MastodonCache = MastodonCacheChunk[];
 export type BlueskyCache = BlueskyCacheChunk[];
+export type LinkedInCache = LinkedInCacheChunk[];
 
 export type PostsCache = Record<
   string,
   {
     [Platform.MASTODON]?: MastodonCache;
     [Platform.BLUESKY]?: BlueskyCache;
+    [Platform.LINKEDIN]?: LinkedInCache;
   }
 >;
 export type ProfileCache = {


### PR DESCRIPTION
## Summary
- support new `LINKEDIN` platform
- cache LinkedIn posts
- implement `linkedinSenderService` using Puppeteer
- export the service
- sync posts to LinkedIn when enabled
- add tests for the new service

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688739d49a948327bd9e82e50d316195