### PR TITLE
Add LinkedIn auth handling

### DIFF
--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -16,10 +16,12 @@ import {
   SYNC_BLUESKY,
   SYNC_DRY_RUN,
   SYNC_MASTODON,
+  SYNC_LINKEDIN,
   TOUITOMAMOUT_VERSION,
   TWITTER_HANDLE,
 } from "../constants";
 import { handleTwitterAuth } from "../helpers/auth/handle-twitter-auth";
+import { handleLinkedinAuth } from "../helpers/auth/handle-linkedin-auth";
 import { createCacheFile } from "../helpers/cache/create-cache";
 import { getCachedPosts } from "../helpers/cache/get-cached-posts";
 import { runMigrations } from "../helpers/cache/run-migrations";
@@ -82,6 +84,10 @@ export const configuration = async (): Promise<{
   const twitterClient = new Scraper();
 
   await handleTwitterAuth(twitterClient);
+
+  if (SYNC_LINKEDIN) {
+    await handleLinkedinAuth();
+  }
 
   let mastodonClient = null;
   if (SYNC_MASTODON) {

--- a/src/helpers/auth/__tests__/handle-linkedin-auth.spec.ts
+++ b/src/helpers/auth/__tests__/handle-linkedin-auth.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, vi } from "vitest";
+
+import { handleLinkedinAuth } from "../handle-linkedin-auth";
+import { saveLinkedinCookies } from "../save-linkedin-cookies";
+
+vi.mock("../save-linkedin-cookies", () => ({
+  saveLinkedinCookies: vi.fn(),
+}));
+
+const { mockedConstants } = vi.hoisted(() => ({
+  mockedConstants: {
+    LINKEDIN_SESSION_COOKIE: "",
+  },
+}));
+
+vi.mock("../../../constants", () => mockedConstants);
+vi.doMock("../../../constants", () => ({
+  LINKEDIN_SESSION_COOKIE: mockedConstants.LINKEDIN_SESSION_COOKIE,
+}));
+
+const cookies = vi.fn().mockResolvedValue([]);
+const setCookie = vi.fn();
+const goto = vi.fn();
+const newPage = vi.fn().mockResolvedValue({ cookies, setCookie, goto });
+const close = vi.fn();
+
+vi.mock("puppeteer", () => ({
+  default: {
+    launch: vi.fn().mockResolvedValue({ newPage, close }),
+  },
+}));
+
+const saveLinkedinCookiesMock = saveLinkedinCookies as unknown as vi.Mock;
+
+describe("handleLinkedinAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when no session cookie", () => {
+    beforeEach(() => {
+      mockedConstants.LINKEDIN_SESSION_COOKIE = "";
+    });
+
+    it("should not init puppeteer", async () => {
+      await handleLinkedinAuth();
+
+      expect(newPage).not.toHaveBeenCalled();
+      expect(saveLinkedinCookiesMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when session cookie is provided", () => {
+    beforeEach(() => {
+      mockedConstants.LINKEDIN_SESSION_COOKIE = "cookie";
+    });
+
+    it("should save cookies", async () => {
+      await handleLinkedinAuth();
+
+      expect(newPage).toHaveBeenCalled();
+      expect(setCookie).toHaveBeenCalledWith({
+        name: "li_at",
+        value: "cookie",
+        domain: ".linkedin.com",
+        path: "/",
+      });
+      expect(goto).toHaveBeenCalledWith("https://www.linkedin.com/feed/");
+      expect(saveLinkedinCookiesMock).toHaveBeenCalledWith([]);
+      expect(close).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/helpers/auth/handle-linkedin-auth.ts
+++ b/src/helpers/auth/handle-linkedin-auth.ts
@@ -1,0 +1,27 @@
+import puppeteer from "puppeteer";
+
+import { LINKEDIN_SESSION_COOKIE } from "../../constants";
+import { saveLinkedinCookies } from "./save-linkedin-cookies";
+
+export const handleLinkedinAuth = async (): Promise<void> => {
+  if (!LINKEDIN_SESSION_COOKIE) {
+    return;
+  }
+
+  const browser = await puppeteer.launch({ headless: "new" });
+  const page = await browser.newPage();
+
+  await page.setCookie({
+    name: "li_at",
+    value: LINKEDIN_SESSION_COOKIE,
+    domain: ".linkedin.com",
+    path: "/",
+  });
+
+  await page.goto("https://www.linkedin.com/feed/");
+  const cookies = await page.cookies();
+
+  await saveLinkedinCookies(cookies);
+
+  await browser.close();
+};

--- a/src/helpers/auth/save-linkedin-cookies.ts
+++ b/src/helpers/auth/save-linkedin-cookies.ts
@@ -1,0 +1,18 @@
+import { writeFile } from "node:fs/promises";
+
+import { STORAGE_DIR } from "../../constants";
+import { Protocol } from "puppeteer";
+
+const LINKEDIN_COOKIES_PATH = `${STORAGE_DIR}/linkedin.cookies.json`;
+
+export const saveLinkedinCookies = async (
+  cookies: Protocol.Network.Cookie[],
+): Promise<void> => {
+  try {
+    await writeFile(LINKEDIN_COOKIES_PATH, JSON.stringify(cookies, null, 2));
+  } catch (err) {
+    console.error("Error updating linkedin cookies file:", err);
+  }
+};
+
+export { LINKEDIN_COOKIES_PATH };


### PR DESCRIPTION
## Summary
- support LinkedIn login with Puppeteer
- save LinkedIn cookies in `linkedin.cookies.json`
- add tests for the new helper
- trigger LinkedIn login during configuration when enabled

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688745c8686483279bd95865e51d89d0