### PR TITLE
Add LinkedIn test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Run test and coverage
         run: npm run test -- --coverage
+        env:
+          CI: true
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/src/services/__tests__/posts-synchronizer-service.spec.ts
+++ b/src/services/__tests__/posts-synchronizer-service.spec.ts
@@ -28,6 +28,7 @@ vi.mock("../../constants", () => ({
   DEBUG: false,
   API_RATE_LIMIT: 1,
   SYNC_DRY_RUN: false,
+  SYNC_LINKEDIN: true,
 }));
 
 vi.mock("../../helpers/cache/get-cached-posts", () => {
@@ -116,6 +117,7 @@ describe("postsSynchronizerService", () => {
 
     expect(mastodonSenderServiceMock).toHaveBeenCalledTimes(3);
     expect(blueskySenderServiceMock).toHaveBeenCalledTimes(3);
+    expect(linkedinSenderServiceMock).toHaveBeenCalledTimes(3);
     expect(writeQueueMock).toHaveBeenCalledWith([]);
     expect(response).toStrictEqual({
       twitterClient,
@@ -156,6 +158,7 @@ describe("postsSynchronizerService", () => {
 
     expect(mastodonSenderServiceMock).toHaveBeenCalledTimes(1);
     expect(blueskySenderServiceMock).toHaveBeenCalledTimes(1);
+    expect(linkedinSenderServiceMock).toHaveBeenCalledTimes(1);
     expect(writeQueueMock).toHaveBeenCalledWith([]);
     expect(response).toStrictEqual({
       twitterClient,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
+      include: ["src/**/*.spec.ts"],
       env: {
         NODE_ENV: "test",
         DEBUG: "false",


### PR DESCRIPTION
## Summary
- run LinkedIn unit tests by including them in vitest config
- run CI tests with `CI=true`
- mock SYNC_LINKEDIN in postsSynchronizerService tests and verify LinkedIn sender usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_68874858110c832790cd54c2c24bb782