### PR TITLE
Add LinkedIn authentication fields

### DIFF
--- a/docs/src/components/environment-generator/generator.js
+++ b/docs/src/components/environment-generator/generator.js
@@ -138,6 +138,26 @@ const Generator = ({ setConfiguration }) => {
         },
       ],
     },
+    linkedin: {
+      name: "🔗 LinkedIn authentication",
+      required: false,
+      enabled: false,
+      fields: [
+        {
+          name: "sessionCookie",
+          type: "string",
+          value: "",
+          env: "LINKEDIN_SESSION_COOKIE",
+        },
+        {
+          name: "enabled",
+          type: "boolean",
+          value: true,
+          hidden: true,
+          env: "SYNC_LINKEDIN",
+        },
+      ],
+    },
     sync: {
       name: "🔄 Synchronization",
       required: false,


### PR DESCRIPTION
## Summary
- add a LinkedIn authentication category in the docs environment generator

## Testing
- `npm test` *(fails: vitest not found, npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887651fd0748327a194e85b07c18ae5