### PR TITLE
Fix LinkedIn sender tweet ID

### DIFF
--- a/src/services/posts-synchronizer.service.ts
+++ b/src/services/posts-synchronizer.service.ts
@@ -69,7 +69,7 @@ export const postsSynchronizerService = async (
         if (SYNC_LINKEDIN) {
           await linkedinSenderService(
             LINKEDIN_SESSION_COOKIE,
-            tweet.id,
+            tweet.id ?? null,
             tweet.text,
             medias,
             log,


### PR DESCRIPTION
## Summary
- ensure `posts-synchronizer.service` passes a nullable tweet id to the LinkedIn sender

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d4e411648327bc5d27c660c4a1f6