### PR TITLE
Fix profile sync platform list

### DIFF
--- a/src/services/profile-synchronizer.service.ts
+++ b/src/services/profile-synchronizer.service.ts
@@ -18,6 +18,11 @@ import { shortenedUrlsReplacer } from "../helpers/url/shortened-urls-replacer";
 import { Platform, ProfileCache, SynchronizerResponse } from "../types";
 import { mediaDownloaderService } from "./media-downloader.service";
 
+const PROFILE_SYNC_PLATFORMS: Platform[] = [
+  Platform.MASTODON,
+  Platform.BLUESKY,
+];
+
 /**
  * An async method in charge of dispatching profile synchronization tasks.
  */
@@ -124,7 +129,7 @@ export const profileSynchronizerService = async (
         return acc;
       }
 
-      const item = Object.values(Platform).reduce((item, platform) => {
+      const item = PROFILE_SYNC_PLATFORMS.reduce((item, platform) => {
         const { property, value } = itemToSync[platform];
         return {
           ...item,


### PR DESCRIPTION
## Summary
- support only Mastodon and Bluesky for profile sync

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d5e2a1cc8327a9fe023f7efc6442