### PR TITLE
Add PUPPETEER_HEADLESS option

### DIFF
--- a/docs/docs/resources/environment-variables.md
+++ b/docs/docs/resources/environment-variables.md
@@ -43,6 +43,7 @@ Even if `TWITTER_USERNAME` & `TWITTER_PASSWORD` are optional, these variables ar
 | Variable                   | Default | Category | Description |
 |----------------------------|:-------:|------------------------------------------|------------------------------------------------|
 | 📌 `LINKEDIN_SESSION_COOKIE` |    ∅    | ![**LinkedIn**::auth](https://img.shields.io/badge/LinkedIn-Auth-0A66C2) | The `li_at` cookie used to authenticate requests.<br/>**[See LinkedIn authentication instructions](./linkedin-authentication).** |
+| `PUPPETEER_HEADLESS` | "new" | ![**LinkedIn**::auth](https://img.shields.io/badge/LinkedIn-Auth-0A66C2) | Whether run Puppeteer in headless mode. Set it to `false` to open a browser window. |
 
 ## Synchronization 🐝
 

--- a/docs/docs/resources/linkedin-authentication.md
+++ b/docs/docs/resources/linkedin-authentication.md
@@ -5,6 +5,7 @@ title: LinkedIn authentication
 # LinkedIn Authentication
 
 Touitomamout uses a headless browser powered by **Puppeteer** to automate posting on LinkedIn. In order for the browser to act as an authenticated user it requires your LinkedIn session cookie (`li_at`).
+If you need to see what Puppeteer is doing—e.g. to troubleshoot login issues such as too many redirects—you can set the environment variable `PUPPETEER_HEADLESS` to `false` to open a visible browser window.
 
 ## Retrieving the `li_at` cookie
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,6 +67,10 @@ export const SYNC_PROFILE_HEADER =
 export const SYNC_DRY_RUN = (process.env.SYNC_DRY_RUN ?? "false") === "true";
 export const DEBUG = (process.env.TOUITOMAMOUT_DEBUG ?? "false") === "true";
 export const DAEMON = (process.env.DAEMON ?? "false") === "true";
+export const PUPPETEER_HEADLESS =
+  process.env.PUPPETEER_HEADLESS === "false"
+    ? false
+    : (process.env.PUPPETEER_HEADLESS as "new" | "true" | undefined) ?? "new";
 export const VOID = "∅";
 export const API_RATE_LIMIT = parseInt(process.env.API_RATE_LIMIT ?? "30");
 export const TOUITOMAMOUT_VERSION = buildInfo.version ?? "0.0.0";

--- a/src/helpers/auth/__tests__/handle-linkedin-auth.spec.ts
+++ b/src/helpers/auth/__tests__/handle-linkedin-auth.spec.ts
@@ -10,12 +10,14 @@ vi.mock("../save-linkedin-cookies", () => ({
 const { mockedConstants } = vi.hoisted(() => ({
   mockedConstants: {
     LINKEDIN_SESSION_COOKIE: "",
+    PUPPETEER_HEADLESS: "new",
   },
 }));
 
 vi.mock("../../../constants", () => mockedConstants);
 vi.doMock("../../../constants", () => ({
   LINKEDIN_SESSION_COOKIE: mockedConstants.LINKEDIN_SESSION_COOKIE,
+  PUPPETEER_HEADLESS: mockedConstants.PUPPETEER_HEADLESS,
 }));
 
 const cookies = vi.fn().mockResolvedValue([]);

--- a/src/helpers/auth/handle-linkedin-auth.ts
+++ b/src/helpers/auth/handle-linkedin-auth.ts
@@ -1,6 +1,6 @@
 import puppeteer from "puppeteer";
 
-import { LINKEDIN_SESSION_COOKIE } from "../../constants";
+import { LINKEDIN_SESSION_COOKIE, PUPPETEER_HEADLESS } from "../../constants";
 import { saveLinkedinCookies } from "./save-linkedin-cookies";
 
 export const handleLinkedinAuth = async (): Promise<void> => {
@@ -8,7 +8,7 @@ export const handleLinkedinAuth = async (): Promise<void> => {
     return;
   }
 
-  const browser = await puppeteer.launch({ headless: "new" });
+  const browser = await puppeteer.launch({ headless: PUPPETEER_HEADLESS });
   const page = await browser.newPage();
 
   await page.setCookie({

--- a/src/services/__tests__/linkedin-sender.service.spec.ts
+++ b/src/services/__tests__/linkedin-sender.service.spec.ts
@@ -7,6 +7,7 @@ import { mediaDownloaderService } from "../media-downloader.service";
 
 vi.mock("../../constants", () => ({
   DEBUG: false,
+  PUPPETEER_HEADLESS: "new",
 }));
 vi.mock("../media-downloader.service", () => ({
   mediaDownloaderService: vi.fn(),

--- a/src/services/linkedin-sender.service.ts
+++ b/src/services/linkedin-sender.service.ts
@@ -1,7 +1,7 @@
 import puppeteer from "puppeteer";
 import { Ora } from "ora";
 
-import { DEBUG, VOID } from "../constants";
+import { DEBUG, VOID, PUPPETEER_HEADLESS } from "../constants";
 import { savePostToCache } from "../helpers/cache/save-post-to-cache";
 import { getPostExcerpt } from "../helpers/post/get-post-excerpt";
 import { LinkedInCacheChunk, Media, Platform } from "../types";
@@ -24,7 +24,7 @@ export const linkedinSenderService = async (
     return;
   }
 
-  const browser = await puppeteer.launch({ headless: "new" });
+  const browser = await puppeteer.launch({ headless: PUPPETEER_HEADLESS });
   const page = await browser.newPage();
   await page.setCookie({
     name: "li_at",


### PR DESCRIPTION
## Summary
- expose a new `PUPPETEER_HEADLESS` constant based on env var
- use `PUPPETEER_HEADLESS` when launching puppeteer
- adjust mocks in LinkedIn tests
- document the new option

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc4b698c8832795289fdd969fd428